### PR TITLE
Add make:content command

### DIFF
--- a/src/Commands/ContentMakeCommand.php
+++ b/src/Commands/ContentMakeCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Plank\Contentable\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'make:content')]
+class ContentMakeCommand extends GeneratorCommand
+{
+    protected $signature = "make:content {name}";
+
+    protected $description = "Create a new content model class to act as a receptacle for content";
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Model';
+
+    public function handle()
+    {
+        if (!is_dir(app_path('Models/Content')) && $this->confirm('Would you like to use App\\Models\\Content as the name space for all generated content?')) {
+            File::makeDirectory(app_path('Models/Content'));
+        }
+
+        parent::handle();
+    }
+
+    protected function getStub()
+    {
+        return $this->resolveStubPath("/stubs/content.php.stub");
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Models/Content')) ? $rootNamespace.'\\Models\\Content' : $rootNamespace.'\\Models';
+    }
+
+}

--- a/src/Commands/ContentMakeCommand.php
+++ b/src/Commands/ContentMakeCommand.php
@@ -9,9 +9,9 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'make:content')]
 class ContentMakeCommand extends GeneratorCommand
 {
-    protected $signature = "make:content {name}";
+    protected $signature = 'make:content {name}';
 
-    protected $description = "Create a new content model class to act as a receptacle for content";
+    protected $description = 'Create a new content model class to act as a receptacle for content';
 
     /**
      * The type of class being generated.
@@ -22,7 +22,7 @@ class ContentMakeCommand extends GeneratorCommand
 
     public function handle()
     {
-        if (!is_dir(app_path('Models/Content')) && $this->confirm('Would you like to use App\\Models\\Content as the name space for all generated content?')) {
+        if (! is_dir(app_path('Models/Content')) && $this->confirm('Would you like to use App\\Models\\Content as the name space for all generated content?')) {
             File::makeDirectory(app_path('Models/Content'));
         }
 
@@ -31,7 +31,7 @@ class ContentMakeCommand extends GeneratorCommand
 
     protected function getStub()
     {
-        return $this->resolveStubPath("/stubs/content.php.stub");
+        return $this->resolveStubPath('/stubs/content.php.stub');
     }
 
     /**
@@ -57,5 +57,4 @@ class ContentMakeCommand extends GeneratorCommand
     {
         return is_dir(app_path('Models/Content')) ? $rootNamespace.'\\Models\\Content' : $rootNamespace.'\\Models';
     }
-
 }

--- a/src/Commands/stubs/content.php.stub
+++ b/src/Commands/stubs/content.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Plank\Contentable\Concerns\CanRender;
+use Plank\Contentable\Models\Module;
+
+class {{ class }} extends Module
+{
+    use HasFactory;
+
+    public function renderHtml() {
+        // TODO: Replace generated stubs
+        return "";
+    }
+}

--- a/src/ContentableServiceProvider.php
+++ b/src/ContentableServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Plank\Contentable;
 
+use Plank\Contentable\Commands\ContentMakeCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -11,6 +12,7 @@ class ContentableServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('contentable')
+            ->hasCommand(ContentMakeCommand::class)
             ->hasConfigFile()
             ->hasMigrations([
                 'create_contents_table',

--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Plank\Contentable\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Plank\Contentable\Concerns\CanRender;
+
+class Module extends Model
+{
+    use CanRender;
+    use HasFactory;
+}


### PR DESCRIPTION
## Summary

closes #3

<!-- Short description of the changes/fixes made. What does this PR solve? -->
Add a basic `Module` class that all `Renderable` modeles can extend to reduce repetition of use statements
Adds the ability to call `php artisan make:content MyContentClass` to automatically generate a class that uses the `CanRender` trait and implements the `Renderable` contract (via inheritance of the base `Module` class)

## Tests
<!-- List the tests that cover the functionality of this PR -->W
WIP
