### PR TITLE
Add missing null-safe for cache clearing

### DIFF
--- a/src/Concerns/HasLayouts.php
+++ b/src/Concerns/HasLayouts.php
@@ -61,7 +61,7 @@ trait HasLayouts
     public static function layouts(): Collection
     {
         if (! static::customizeableLayout()) {
-            return new Collection();
+            return new Collection;
         }
 
         $layoutModel = static::layoutModel();

--- a/src/Exceptions/ContentableException.php
+++ b/src/Exceptions/ContentableException.php
@@ -4,6 +4,4 @@ namespace Plank\Contentable\Exceptions;
 
 use Exception;
 
-class ContentableException extends Exception
-{
-}
+class ContentableException extends Exception {}

--- a/src/Models/Content.php
+++ b/src/Models/Content.php
@@ -21,7 +21,7 @@ class Content extends Model implements ContentInterface
     protected static function boot()
     {
         static::saved(function (ContentInterface $content) {
-            $content->contentable->clearCache();
+            $content->contentable?->clearCache();
         });
 
         parent::boot();


### PR DESCRIPTION
## Summary

Closes #16

<!-- Short description of the changes/fixes made. What does this PR solve? -->
Adds a missing null-safe operator when content is saved which was throwing errors when ever a piece of content's contentable was null. This increases compatibility with packages like Plank/Snapshots. 

