### PR TITLE
Add Laravel 12.x support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
+        php: [8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,4 +71,4 @@ jobs:
       - uses: qltysh/qlty-action/coverage@v1
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
-          files: build/coverage/clover.xml
+          files: build/logs/clover.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,11 +65,10 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-      - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      - name: Run Tests with coverage
+        run: composer test-coverage
+
+      - uses: qltysh/qlty-action/coverage@v1
         with:
-          coverageCommand: composer test-coverage
-          coverageLocations: |
-            ${{github.workspace}}/build/logs/clover.xml:clover
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: build/coverage/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/tests/Feature/LayoutsTest.php
+++ b/tests/Feature/LayoutsTest.php
@@ -11,7 +11,7 @@ use Plank\Contentable\Tests\Helper\Models\Product;
 
 use function Pest\Laravel\artisan;
 
-describe('It throws errors when layouts do not exist', function () {
+describe('errors regarding layouts', function () {
     it('throws an error when the Detail layout doesnt exist', function () {
         Product::factory()->create()->layout();
     })->throws(MissingLayoutException::class);
@@ -21,7 +21,7 @@ describe('It throws errors when layouts do not exist', function () {
     })->throws(MissingLayoutException::class);
 });
 
-describe('It returns Blade Layouts for Layoutables', function () {
+describe('Layoutables return Blade layouts', function () {
     beforeEach(function () {
         setBladePath('sync');
         artisan('contentable:sync')->assertExitCode(0);
@@ -74,7 +74,7 @@ describe('It returns Blade Layouts for Layoutables', function () {
     });
 });
 
-describe('It returns Inertia Layouts for Layoutables', function () {
+describe('Layoutables return Inertia Layouts', function () {
     beforeEach(function () {
         config()->set('contentable.layouts.mode', LayoutMode::InertiaJsx);
         setInertiaPath('Sync');
@@ -120,7 +120,7 @@ describe('It returns Inertia Layouts for Layoutables', function () {
     });
 });
 
-describe('It returns layout options for blade', function () {
+describe('layout options for blade', function () {
     beforeEach(function () {
         setBladePath('sync');
         artisan('contentable:sync')->assertExitCode(0);
@@ -210,7 +210,7 @@ describe('It returns layout options for blade', function () {
     });
 });
 
-describe('It returns the default layouts for non-customizeable Layoutables with Inertia', function () {
+describe('non-customizeable Layoutables with Inertia returns the default layouts', function () {
     beforeEach(function () {
         config()->set('contentable.layouts.mode', LayoutMode::InertiaJsx);
         setInertiaPath('Sync');

--- a/tests/Feature/SyncLayoutsTest.php
+++ b/tests/Feature/SyncLayoutsTest.php
@@ -10,7 +10,7 @@ use Plank\Contentable\Tests\Helper\Models\Product;
 
 use function Pest\Laravel\artisan;
 
-describe('It syncs Layouts for Blade', function () {
+describe('Layouts for Blade', function () {
     beforeEach(function () {
         setBladePath('sync');
     });
@@ -143,7 +143,7 @@ describe('It syncs Layouts for Blade', function () {
     });
 });
 
-describe('It syncs Layouts for Inertia', function () {
+describe('Layouts for Inertia', function () {
     beforeEach(function () {
         config()->set('contentable.layouts.mode', LayoutMode::InertiaJsx);
         setInertiaPath('Sync');


### PR DESCRIPTION
## Summary

closes #18

<!-- Short description of the changes/fixes made. What does this PR solve? -->
Add support for Laravel 12.x to package generally. Since Laravel 10.x supports up to PHP 8.3 these will be bundled together.
Adds new Qlty.sh coverage and analysis tools. 
Renames test sets to match Pest conventions
